### PR TITLE
feat: impl skip read

### DIFF
--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -17,6 +17,7 @@ import {
   configKeys,
   getUserConfig,
   updateUserConfig,
+  GetInfoOptions,
 } from "@dhu/core";
 import {
   renderLogo,
@@ -66,13 +67,15 @@ cli
   .command("info", "Get info")
   .option("--all", "retrieve all info")
   .option("--head", "launch headfully")
+  .option("-r,--includeRead", "include read info")
   .option("-c,--content", "get content info")
   .option("-a,--attachments", "download attachments")
   .option("--dir <dir>", "path to save download attachments")
   .action(async (option) => {
-    const { all, attachments, content, dir } = option;
-    const getInfoOptions = {
-      all: Boolean(all),
+    const { all, attachments, includeRead, content, dir } = option;
+    const getInfoOptions: GetInfoOptions = {
+      listAll: Boolean(all),
+      skipRead: !includeRead,
       content: Boolean(content),
       attachments: Boolean(attachments),
       dir: dir ?? process.cwd(),

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dhu/cli",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "main": "bin/index.js",
   "license": "MIT",
   "bin": {
@@ -15,7 +15,7 @@
     "clean": "rm -rf ./bin"
   },
   "dependencies": {
-    "@dhu/core": "^0.3.7",
+    "@dhu/core": "^0.3.8",
     "cac": "^6.7.3",
     "chalk": "^4.1.1",
     "immer": "^9.0.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dhu/core",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "main": "dist/index.js",
   "license": "MIT",
   "scripts": {

--- a/packages/core/selectors.ts
+++ b/packages/core/selectors.ts
@@ -29,6 +29,7 @@ export const INFO_ALL = "#funcForm\\:tabArea\\:1\\:j_idt402";
 export const INFO_GENERAL_ALL = "#funcForm\\:tabArea > ul > li:nth-child(2) > a";
 export const INFO_CLASS_ALL = "#funcForm\\:tabArea > ul > li:nth-child(3) > a";
 
+export const INFO_GENERAL_ITEM_STATE = "#funcForm\\:tabArea\\:1\\:allScr > div > span > div:nth-child(2)";
 export const INFO_GENERAL_ITEM = "#funcForm\\:tabArea\\:1\\:allScr > div > dl > a";
 export const INFO_CLASS_ITEM = "#funcForm\\:tabArea\\:2\\:allScr > div > dl > a";
 export const INFO_ITEM_ATTACHMENT_OPEN = "#bsd00702\\:ch\\:j_idt502";

--- a/packages/syllabus-site/package.json
+++ b/packages/syllabus-site/package.json
@@ -12,7 +12,7 @@
     "gen": "cp ./data/search.json ./functions/search.json && gridsome build"
   },
   "devDependencies": {
-    "@dhu/core": "^0.3.7",
+    "@dhu/core": "^0.3.8",
     "gridsome": "^0.7.23",
     "sass": "^1.32.12",
     "sass-loader": "^10.1.1",


### PR DESCRIPTION
Changed `GetInfoOptions` interface

Before:

```ts
export interface GetInfoOptions {
  all?: boolean;
  content?: boolean;
  attachments?: boolean;
  dir: string;
}

export interface GetInfoItemOptions extends GetInfoOptions {
  navigate?: boolean;
}
```

After

```ts
export type GetInfoOptions = {
  listAll?: boolean;
  skipRead?: boolean;
  content?: boolean;
} & ({ attachments: true; dir: string } | { attachments?: false });

export type GetInfoItemOptions = GetInfoOptions & {
  navigate?: boolean;
};
```

This means:

- `all` is renamed to `listAll`
- `skipRead`  is default to true
- not need to set "dir" without `attachments: true`